### PR TITLE
Fix dependency jar order and falsely identifying test sources as normal sources

### DIFF
--- a/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
@@ -356,7 +356,11 @@ public class CreateModule {
 			projectSB.append(File.separatorChar);
 			projectSB.append("src\n");
 		}
-		else if (Files.exists(moduleSrcPath)) {
+		else if (
+			Files.exists(
+				moduleSrcPath.resolve("com")) ||
+				Files.exists(moduleSrcPath.resolve("main"))) {
+
 			projectSB.append("file.reference.");
 			projectSB.append(moduleName);
 			projectSB.append("-src=");
@@ -374,13 +378,13 @@ public class CreateModule {
 			else {
 				projectSB.append("\n");
 			}
-		}
 
-		projectSB.append("src.");
-		projectSB.append(moduleName);
-		projectSB.append(".dir=${file.reference.");
-		projectSB.append(moduleName);
-		projectSB.append("-src}\n");
+			projectSB.append("src.");
+			projectSB.append(moduleName);
+			projectSB.append(".dir=${file.reference.");
+			projectSB.append(moduleName);
+			projectSB.append("-src}\n");
+		}
 
 		Path mainResourcesPath = Paths.get(
 			moduleSrcPath.toString(), "main", "resources");

--- a/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
@@ -14,7 +14,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
@@ -198,7 +198,7 @@ public class CreateModule {
 			String compileDependencies =
 				dependencyProperties.getProperty("compile");
 
-			Set<String> compileSet = new HashSet<>();
+			Set<String> compileSet = new LinkedHashSet<>();
 
 			compileSet.addAll(
 				Arrays.asList(
@@ -212,7 +212,7 @@ public class CreateModule {
 				compileTestDependencies = "";
 			}
 
-			Set<String> compileTestSet = new HashSet<>();
+			Set<String> compileTestSet = new LinkedHashSet<>();
 
 			compileTestSet.addAll(
 				Arrays.asList(


### PR DESCRIPTION
First commit is for modules that has the structure of src/test or src/testIntegration, the current project would detect those as both source and test source giving package name errors.
Second commit is to keep the dependencies in order so if a transitive dependency has the same class it won't be loaded first.
