### PR TITLE
Some modules no longer contains build.xml

### DIFF
--- a/common/shared-macrodefs.xml
+++ b/common/shared-macrodefs.xml
@@ -104,6 +104,7 @@ src.portal-web-functional.dir=$${file.reference.portal-web-functional.src}
 								<contains string="${exclude.modules}" substring="${src.dir.name}" />
 							</not>
 							<or>
+								<available file="${src.dir}/build.gradle" />
 								<available file="${src.dir}/build.xml" />
 								<available file="${src.dir}/web.xml" />
 							</or>

--- a/java-application-module-project/build.xml
+++ b/java-application-module-project/build.xml
@@ -77,6 +77,7 @@ reference.@{src.dir.name}.jar=$${project.@{src.dir.name}}/dist/@{src.dir.name}.j
 								<contains string="${exclude.modules}" substring="${src.dir.name}" />
 							</not>
 							<or>
+								<available file="${src.dir}/build.gradle" />
 								<available file="${src.dir}/build.xml" />
 								<available file="${src.dir}/web.xml" />
 							</or>


### PR DESCRIPTION
This fix is needed in order to correctly build the project, please apply this before rebuilding the project.
