### PR TITLE
Add target to scan for new module additions

### DIFF
--- a/common/shared-macrodefs.xml
+++ b/common/shared-macrodefs.xml
@@ -117,7 +117,6 @@ src.portal-web-functional.dir=$${file.reference.portal-web-functional.src}
 			</for>
 
 			<java classname="com.liferay.netbeansproject.ProcessGradle" classpath="classes">
-				<arg value="display.gradle=${display.gradle.process.output}" />
 				<arg value="portal.dir=@{portal.dir}" />
 				<arg value="project.dir=@{project.dir}" />
 				<arg value="work.dir=@{portal.dir}/modules" />

--- a/common/src/com/liferay/netbeansproject/util/ZipUtil.java
+++ b/common/src/com/liferay/netbeansproject/util/ZipUtil.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.netbeansproject.util;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * @author Tom Wang
+ */
+public class ZipUtil {
+
+	public static void unZip(Path zipPath, final Path destinationPath)
+		throws IOException {
+
+		FileSystem fileSystem = FileSystems.newFileSystem(zipPath,null);
+
+		for (final Path path : fileSystem.getRootDirectories()) {
+			Files.walkFileTree(
+				path,
+				new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult visitFile(
+					Path vistFilePath, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path relativeDir = path.relativize(vistFilePath);
+
+					Path pastePath = destinationPath.resolve(
+						relativeDir.toString());
+
+					if (!Files.exists(pastePath)) {
+						Files.createDirectories(pastePath);
+					}
+
+					Files.copy(
+						vistFilePath, pastePath,
+						StandardCopyOption.REPLACE_EXISTING);
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+		}
+	}
+
+}

--- a/java-application-module-project/build.properties
+++ b/java-application-module-project/build.properties
@@ -15,6 +15,8 @@ portal.dir=
 ## project.dir must be absolute directory
 project.dir=portal
 
+blacklist.dirs=.git,.gradle,build,sample,tools
+
 exclude.modules=\
     hook_tmpl,\
     portal-client,\

--- a/java-application-module-project/build.xml
+++ b/java-application-module-project/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="Liferay-Source-Netbeans-Project" default="build" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
+<project name="Liferay-Source-Netbeans-Project" default="add" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
 
 	<import file="../common/shared-macrodefs.xml" />
 
@@ -18,6 +18,32 @@ reference.@{src.dir.name}.jar=$${project.@{src.dir.name}}/dist/@{src.dir.name}.j
 			/>
 		</sequential>
 	</macrodef>
+
+	<target name="add">
+		<if>
+			<available file="${project.dir}" type="dir" />
+			<then>
+				<mkdir dir="classes" />
+
+				<javac
+					debug="true"
+					destdir="classes"
+					includeantruntime="false" >
+
+					<src path="../common/src" />
+					<src path="src" />
+				</javac>
+
+				<java classname="com.liferay.netbeansproject.AddModule" classpath="classes">
+					<arg value="portal.dir=${portal.dir}" />
+				</java>
+
+			</then>
+			<else>
+				<antcall target="build" />
+			</else>
+		</if>
+	</target>
 
 	<target name="build">
 		<for list="${portal.dir}" param="portal.dir">

--- a/java-application-module-project/src/com/liferay/netbeansproject/AddModule.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/AddModule.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.netbeansproject;
+
+import com.liferay.netbeansproject.util.PropertiesUtil;
+import com.liferay.netbeansproject.util.StringUtil;
+import com.liferay.netbeansproject.util.ZipUtil;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * @author tom
+ */
+public class AddModule {
+	public static void main(String[] args) throws IOException {
+		AddModule addModule = new AddModule();
+
+		addModule.addModule();
+	}
+
+	public void addModule() throws IOException {
+		Properties properties = PropertiesUtil.loadProperties(
+			Paths.get("build.properties"));
+
+		String portals = properties.getProperty("portal.dir");
+
+		for (String portal : StringUtil.split(portals, ',')) {
+			final Path portalPath = Paths.get(portal);
+
+			Path portalName = portalPath.getFileName();
+
+			final Path projectRootPath = Paths.get(
+				properties.getProperty("project.dir"), portalName.toString());
+
+			final List<String> moduleNames =
+					_getExistingModules(projectRootPath);
+
+			final String blackListDirs = properties.getProperty(
+				"blacklist.dirs");
+
+			Files.walkFileTree(portalPath, new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult preVisitDirectory(
+						Path path, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Path pathFileName = path.getFileName();
+
+					if (blackListDirs.contains(pathFileName.toString())) {
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					if (Files.exists(path.resolve("src"))) {
+						try {
+							Path moduleName = _getModuleName(path);
+
+							if (!moduleNames.contains(moduleName.toString())) {
+								ProcessGradle.processGradle(
+									portalPath, projectRootPath, path);
+
+								ZipUtil.unZip(
+									Paths.get("CleanModule.zip"),
+									projectRootPath.resolve("modules/" +
+										moduleName.toString()));
+
+								CreateModule.createModule(
+									projectRootPath, path, portalPath,
+									new String[0]);
+							}
+						}
+						catch (Exception ex) {
+
+						}
+
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
+		}
+	}
+
+	private Path _getModuleName(Path modulePath) {
+		Path moduleName = modulePath.getFileName();
+
+		if ("WEB-INF".equals(moduleName.toString())) {
+			moduleName = modulePath.getParent();
+			moduleName = moduleName.getParent();
+			moduleName = moduleName.getFileName();
+		}
+
+		return moduleName;
+	}
+
+	private List<String> _getExistingModules(Path projectRootPath)
+		throws IOException {
+
+		List<String> moduleNames = new ArrayList<>();
+
+		DirectoryStream<Path> directoryStream = Files.newDirectoryStream(
+				projectRootPath.resolve("modules"));
+
+		for (Path path :directoryStream) {
+			Path fileName = path.getFileName();
+			moduleNames.add(fileName.toString());
+		}
+
+		return moduleNames;
+	}
+}

--- a/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
@@ -306,11 +306,13 @@ public class CreateModule {
 			projectSB.setLength(projectSB.length() - 3);
 
 			if (projectName.equals("portal-impl")) {
-				projectSB.append("\nfile.reference.portal-test-integration-src=");
+				projectSB.append(
+					"\nfile.reference.portal-test-integration-src=");
 				projectSB.append(projectInfo.getPortalDir());
 				projectSB.append("/portal-test-integration/src\n");
 				projectSB.append(
-					"src.test.dir=${file.reference.portal-test-integration-src}");
+					"src.test.dir=${file.reference.portal-test-integration-" +
+						"src}");
 			}
 
 			if (projectName.equals("portal-kernel")) {

--- a/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
@@ -29,6 +29,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
 public class CreateModule {
 
 	public static void main(String[] args) throws Exception {
@@ -60,7 +61,6 @@ public class CreateModule {
 			projectDependencies = projectDependencyProperties.getProperty(
 				"portal.module.dependencies");
 		}
-
 		ProjectInfo projectInfo = new ProjectInfo(
 			moduleName, portalDir, modulePath,
 			StringUtil.split(projectDependencies, ','), moduleList);
@@ -173,6 +173,7 @@ public class CreateModule {
 			Paths.get(
 				modulePath.toString(), projectName,
 				"nbproject", "project.properties");
+
 		try (BufferedWriter bufferedWriter = Files.newBufferedWriter(
 				projectPropertiesPath, Charset.defaultCharset(),
 				StandardOpenOption.APPEND)) {
@@ -204,6 +205,10 @@ public class CreateModule {
 			}
 
 			Path dependenciesDirPath = projectPath.resolve("dependencies");
+
+			if (!Files.exists(dependenciesDirPath)) {
+				Files.createDirectory(dependenciesDirPath);
+			}
 
 			Path dependenciesPath = dependenciesDirPath.resolve(projectName);
 

--- a/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/CreateModule.java
@@ -36,12 +36,13 @@ public class CreateModule {
 
 		createModule(
 			Paths.get(arguments.get("project.dir")),
-			Paths.get(arguments.get("src.dir")), arguments.get("portal.dir"),
+			Paths.get(arguments.get("src.dir")),
+			Paths.get(arguments.get("portal.dir")),
 			StringUtil.split(arguments.get("module.list"), ','));
 	}
 
 	public static void createModule(
-			Path projectPath, Path modulePath, String portalDir,
+			Path projectPath, Path modulePath, Path portalDir,
 			String[] moduleList)
 		throws Exception {
 
@@ -288,18 +289,17 @@ public class CreateModule {
 
 			projectInfo.setDependenciesModuleMap(dependenciesModuleMap);
 
-			Path developmentPath = Paths.get(
-				projectInfo.getPortalDir(),"lib", "development");
+			Path portalDir = projectInfo.getPortalDir();
+
+			Path developmentPath = portalDir.resolve("lib/development");
 
 			_appendJavacClasspath(developmentPath.toFile(), projectSB);
 
-			Path globalPath = Paths.get(
-				projectInfo.getPortalDir(),"lib", "global");
+			Path globalPath = portalDir.resolve("lib/global");
 
 			_appendJavacClasspath(globalPath.toFile(), projectSB);
 
-			Path portalPath = Paths.get(
-				projectInfo.getPortalDir(),"lib", "portal");
+			Path portalPath = portalDir.resolve("lib/portal");
 
 			_appendJavacClasspath(portalPath.toFile(), projectSB);
 
@@ -541,7 +541,7 @@ public class CreateModule {
 
 		Path projectPath = projectInfo.getFullPath();
 
-		Path portalPath = Paths.get(projectInfo.getPortalDir());
+		Path portalPath = projectInfo.getPortalDir();
 
 		Path portalParentPath = portalPath.getParent();
 
@@ -775,7 +775,7 @@ public class CreateModule {
 			return _moduleMap;
 		}
 
-		public String getPortalDir() {
+		public Path getPortalDir() {
 			return _portalDir;
 		}
 
@@ -794,7 +794,7 @@ public class CreateModule {
 		}
 
 		private ProjectInfo(
-			String projectName, String portalDir, Path fullPath,
+			String projectName, Path portalDir, Path fullPath,
 			String[] projectLibs, String[] moduleList) {
 
 			_projectName = projectName;
@@ -819,7 +819,7 @@ public class CreateModule {
 		private final Path _fullPath;
 		private Map<String, ModuleInfo> _dependenciesModuleMap;
 		private final Map<String, Path> _moduleMap;
-		private final String _portalDir;
+		private final Path _portalDir;
 		private final String[] _projectLib;
 		private final String _projectName;
 

--- a/java-application-module-project/src/com/liferay/netbeansproject/ProcessGradle.java
+++ b/java-application-module-project/src/com/liferay/netbeansproject/ProcessGradle.java
@@ -1,6 +1,7 @@
 package com.liferay.netbeansproject;
 
 import com.liferay.netbeansproject.util.ArgumentsUtil;
+import com.liferay.netbeansproject.util.PropertiesUtil;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -10,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * @author tom
@@ -18,9 +20,19 @@ public class ProcessGradle {
 	public static void main(String[] args) throws Exception {
 		Map<String, String> arguments = ArgumentsUtil.parseArguments(args);
 
-		Path portalDirPath = Paths.get(arguments.get("portal.dir"));
-		Path projectDirPath = Paths.get(arguments.get("project.dir"));
-		Path workDirPath = Paths.get(arguments.get("work.dir"));
+		processGradle(
+			Paths.get(arguments.get("portal.dir")),
+			Paths.get(arguments.get("project.dir")),
+			Paths.get(arguments.get("work.dir")));
+	}
+
+	public static void processGradle(
+			Path portalDirPath, Path projectDirPath,
+			Path workDirPath)
+		throws Exception {
+
+		Properties properties = PropertiesUtil.loadProperties(
+			Paths.get("build.properties"));
 
 		Path gradlewPath = portalDirPath.resolve("gradlew");
 
@@ -55,7 +67,9 @@ public class ProcessGradle {
 
 		Process process = processBuilder.start();
 
-		if (Boolean.valueOf(arguments.get("display.gradle"))) {
+		if (Boolean.valueOf(
+			properties.getProperty("display.gradle.process.output"))) {
+
 			String line;
 
 			try(BufferedReader br = new BufferedReader(new InputStreamReader(


### PR DESCRIPTION
With this pull we set the new target add as default.

Add target will check if there is existing netbeans project, if there is none it will invoke the old logic to build all. 

If it exist it will invoke the new java logic to compare modules. Once it identifies new module it will unzip the module files, call gradle to get dependencies, and create the module.
