### PR TITLE
Quick patch for module build.gradle spacing issue

### DIFF
--- a/src/com/liferay/netbeansproject/container/Module.java
+++ b/src/com/liferay/netbeansproject/container/Module.java
@@ -96,8 +96,7 @@ public class Module implements Comparable<Module> {
 			_resolveResourcePath(modulePath, "testIntegration"),
 			moduleDependencies, jarDependencies,
 			_resolvePortalModuleDependencies(
-				portalModuleDependencyProperties,
-				moduleName.toString()),
+				portalModuleDependencyProperties, moduleName.toString()),
 			checksum);
 
 		if (projectPath != null) {

--- a/src/com/liferay/netbeansproject/util/GradleUtil.java
+++ b/src/com/liferay/netbeansproject/util/GradleUtil.java
@@ -161,7 +161,7 @@ public class GradleUtil {
 		for (String line : Files.readAllLines(buildGradlePath)) {
 			Path moduleProjectPath = null;
 
-			if (line.contains(" project(")) {
+			if (line.contains(" project(") || line.contains(" project (")) {
 				moduleProjectPath = Paths.get(
 					"modules",
 					StringUtil.split(

--- a/src/resources/group_project_xml.ftl
+++ b/src/resources/group_project_xml.ftl
@@ -14,6 +14,7 @@
 				</#if>
 				</#list>
 			</source-roots>
+
 			<test-roots>
 				<#list moduleList as module>
 				<#if module.getTestUnitPath()??>
@@ -31,6 +32,7 @@
 				</#list>
 			</test-roots>
 		</data>
+
 		<references xmlns="http://www.netbeans.org/ns/ant-project-references/1">
 			<#list moduleDependencies as dependency>
 				<reference>

--- a/src/resources/project_xml.ftl
+++ b/src/resources/project_xml.ftl
@@ -18,6 +18,7 @@
 					<root id="src.test.dir" name="portal-test"/>
 				</#if>
 			</source-roots>
+
 			<test-roots>
 				<#if module.getTestUnitPath()??>
 					<root id="test.${module.getModuleName()}.test-unit.dir" name="test-unit"/>
@@ -33,6 +34,7 @@
 				</#if>
 			</test-roots>
 		</data>
+
 		<references xmlns="http://www.netbeans.org/ns/ant-project-references/1">
 			<#list module.getModuleDependencies() as dependency>
 				<reference>

--- a/src/resources/umbrella_project_xml.ftl
+++ b/src/resources/umbrella_project_xml.ftl
@@ -10,6 +10,7 @@
 			</source-roots>
 			<test-roots/>
 		</data>
+
 		<references xmlns="http://www.netbeans.org/ns/ant-project-references/1">
 			<#list moduleNames as moduleName>
 			<reference>


### PR DESCRIPTION
currently in build.gradle, the syntax `project ("xyz")` is allowed (the space between project and "(") and not picked up by source formatter.

If this is acceptable then this patch will allow us to pick up those dependencies.
